### PR TITLE
Update SHA of Android SDK license

### DIFF
--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -54,7 +54,7 @@ function installAndroidSDK {
 
   mkdir -p "$ANDROID_HOME/licenses/"
   echo > "$ANDROID_HOME/licenses/android-sdk-license"
-  echo -n d56f5187479451eabf01fb78af6dfcb131a6481e > "$ANDROID_HOME/licenses/android-sdk-license"
+  echo -n 24333f8a63b6825ea9c5514f83c2829b004d1fee > "$ANDROID_HOME/licenses/android-sdk-license"
 
   installsdk 'platforms;android-28' 'cmake;3.6.4111459'
 }


### PR DESCRIPTION
The SHA of Android SDK license has changed as of January 16, 2019 and this is the new hash.